### PR TITLE
Add bitcoinbottom.app to Analytics & On-chain Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ News outlets for Bitcoin related products and services.
 # Payment Processors
 Stuff that helps you process payments using bitcoins.
 * [BitPay](https://bitpay.com)
+
+# Analytics & On-chain Tools
+On-chain analytics and market cycle tools.
+* [bitcoinbottom.app](https://bitcoinbottom.app) - Free Bitcoin cycle bottom probability tracker. Aggregates 25 on-chain signals (MVRV Z-Score, Puell Multiple, Hash Ribbon, Fear & Greed, etc.) into a daily score. No signup required.


### PR DESCRIPTION
Adds [bitcoinbottom.app](https://bitcoinbottom.app) — a free Bitcoin cycle bottom probability tracker that aggregates 25 on-chain signals (MVRV Z-Score, Puell Multiple, Hash Ribbon, Fear & Greed, etc.) into a daily probability score. No signup required.